### PR TITLE
[systemd] Increase syncd startup script timeout

### DIFF
--- a/files/build_templates/per_namespace/syncd.service.j2
+++ b/files/build_templates/per_namespace/syncd.service.j2
@@ -26,7 +26,7 @@ ExecStartPre=/usr/local/bin/syncd.sh start{% if multi_instance == 'true' %} %i{%
 ExecStart=/usr/local/bin/syncd.sh wait{% if multi_instance == 'true' %} %i{% endif %}
 ExecStop=/usr/local/bin/syncd.sh stop{% if multi_instance == 'true' %} %i{% endif %}
 {% if sonic_asic_platform == 'mellanox' %}
-TimeoutStartSec=150
+TimeoutStartSec=480
 {% endif %}
 
 [Install]

--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -21,9 +21,11 @@ function startplatform() {
             fi
         fi
 
+        debug "Starting Firmware update procedure"
         /usr/bin/mst start --with_i2cdev
         /usr/bin/mlnx-fw-upgrade.sh
         /etc/init.d/sxdkernel start
+        debug "Firmware update procedure ended"
     fi
 
     if [[ x"$WARM_BOOT" != x"true" ]]; then


### PR DESCRIPTION
[systemd] Increase syncd startup script timeout to support FW upgrade on init.
Add prints to syslog in syncd startup script to indicate FW upgrade is in progress.

Important notes:
Please cherry-pick to branches 202012 and 201911.
This PR is related to the following PRs but can be merged without them.
Azure/sonic-sairedis#774
liorghub/sonic-swss/pull/3

Signed-off-by: liora <liora@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**
To support FW upgrade on init.
**- How I did it**
Change timeout value
**- How to verify it**
I manually changed ASIC and Gearbox FW followed by hard reset in order for FW upgrade to take place on init.
**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [ ] 202006
- [x] 202012

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
