### PR TITLE
[Mellanox]: disable syseepromd on simx systems

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700_simx-r0/pmon_daemon_control.json
+++ b/device/mellanox/x86_64-mlnx_msn2700_simx-r0/pmon_daemon_control.json
@@ -3,5 +3,6 @@
         "skip_xcvrd": true,
         "skip_psud": true,
         "skip_pcied": true,
-        "skip_thermalctld": true
+        "skip_thermalctld": true,
+        "skip_syseepromd": true
 }

--- a/device/mellanox/x86_64-mlnx_msn3700_simx-r0/pmon_daemon_control.json
+++ b/device/mellanox/x86_64-mlnx_msn3700_simx-r0/pmon_daemon_control.json
@@ -3,5 +3,6 @@
         "skip_xcvrd": true,
         "skip_psud": true,
         "skip_pcied": true,
-        "skip_thermalctld": true
+        "skip_thermalctld": true,
+        "skip_syseepromd": true
 }

--- a/device/mellanox/x86_64-mlnx_msn4700_simx-r0/pmon_daemon_control.json
+++ b/device/mellanox/x86_64-mlnx_msn4700_simx-r0/pmon_daemon_control.json
@@ -3,5 +3,6 @@
         "skip_xcvrd": true,
         "skip_psud": true,
         "skip_pcied": true,
-        "skip_thermalctld": true
+        "skip_thermalctld": true,
+        "skip_syseepromd": true
 }


### PR DESCRIPTION
[Mellanox]: disable syseepromd on simx systems

Signed-off-by: liora <liora@nvidia.com>

**- Why I did it**
Service syseepromd should not run on simx systems.

**- How I did it**
Update simx systems pmon_daemon_control.json which is being written to supervisord.conf

**- How to verify it**
Verify supervisord status that thermalctld is not running.

**- Which release branch to backport**
- [ ] 201811
- [x] 201911
- [ ] 202006
- [x] 202012