### PR TITLE
[sonic-cfggen] Allow cfggen to work on system without ports

### DIFF
--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -314,11 +314,8 @@ def main():
         if args.port_config is None:
             args.port_config = device_info.get_path_to_port_config_file(hwsku)
         (ports, _, _) = get_port_config(hwsku, platform, args.port_config, asic_id)
-        if not ports:
-            print('Failed to get port config', file=sys.stderr)
-            sys.exit(1)
-        deep_update(data, {'PORT': ports})
-
+        if ports:
+            deep_update(data, {'PORT': ports})
         brkout_table = get_breakout_mode(hwsku, platform, args.port_config)
         if  brkout_table is not None:
             deep_update(data, {'BREAKOUT_CFG': brkout_table})


### PR DESCRIPTION
Signed-off-by: liora <liora@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Allow cfggen to work on system with no ports in platform.json nor in port_config.ini

#### How I did it
Add json write of PORT section only if the dictionary that contains the ports is not empty.  

#### How to verify it
sonic-cfggen -k ACS-MSN3700 -H -j /etc/sonic/init_cfg.json --print-data

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


#### A picture of a cute animal (not mandatory but encouraged)

