### PR TITLE
[Monit] Fix in memory_checker, skip fetching running containers if Docker engine is not running

### DIFF
--- a/files/image_config/monit/memory_checker
+++ b/files/image_config/monit/memory_checker
@@ -24,7 +24,6 @@ import subprocess
 import sys
 import syslog
 import re
-import os
 
 import docker
 
@@ -97,9 +96,9 @@ def check_memory_usage(container_name, threshold_value):
         sys.exit(4)
 
 
-def is_service_active(feat):
-    status = os.system('systemctl is-active --quiet {}'.format(feat))
-    return status == 0
+def is_service_active(service):
+    status = subprocess.run("systemctl is-active --quiet {}".format(service), shell=True, check=False)
+    return status.returncode == 0
 
 
 def get_running_container_names():
@@ -111,18 +110,19 @@ def get_running_container_names():
     Returns:
         running_container_names: A list indicates names of running containers.
     """
-    running_container_names = []
+    if not is_service_active("docker"):
+        syslog.syslog(syslog.LOG_INFO,"Skipping memory check since Docker engine is down")
+        return []
 
-    if (is_service_active("docker")):
-        try:
-            docker_client = docker.DockerClient(base_url='unix://var/run/docker.sock')
-            running_container_list = docker_client.containers.list(filters={"status": "running"})
-            running_container_names = [ container.name for container in running_container_list ]
-        except (docker.errors.APIError, docker.errors.DockerException) as err:
-            syslog.syslog(syslog.LOG_ERR,
-                          "Failed to retrieve the running container list from docker daemon! Error message is: '{}'"
-                          .format(err))
-            sys.exit(5)
+    try:
+        docker_client = docker.DockerClient(base_url='unix://var/run/docker.sock')
+        running_container_list = docker_client.containers.list(filters={"status": "running"})
+        running_container_names = [ container.name for container in running_container_list ]
+    except (docker.errors.APIError, docker.errors.DockerException) as err:
+        syslog.syslog(syslog.LOG_ERR,
+                      "Failed to retrieve the running container list from docker daemon! Error message is: '{}'"
+                      .format(err))
+        sys.exit(5)
 
     return running_container_names
 

--- a/files/image_config/monit/memory_checker
+++ b/files/image_config/monit/memory_checker
@@ -110,10 +110,6 @@ def get_running_container_names():
     Returns:
         running_container_names: A list indicates names of running containers.
     """
-    if not is_service_active("docker"):
-        syslog.syslog(syslog.LOG_INFO,"Skipping memory check since Docker engine is down")
-        return []
-
     try:
         docker_client = docker.DockerClient(base_url='unix://var/run/docker.sock')
         running_container_list = docker_client.containers.list(filters={"status": "running"})
@@ -136,6 +132,10 @@ def main():
     # remove this in the new version since we want to read this value from 'CONFIG_DB'.
     parser.add_argument("threshold_value", type=int, help="threshold value in bytes")
     args = parser.parse_args()
+
+    if not is_service_active("docker"):
+        syslog.syslog(syslog.LOG_INFO,"Skipping memory check: docker daemon is down")
+        sys.exit(0)
 
     running_container_names = get_running_container_names()
     if args.container_name in running_container_names:

--- a/files/image_config/monit/memory_checker
+++ b/files/image_config/monit/memory_checker
@@ -24,6 +24,7 @@ import subprocess
 import sys
 import syslog
 import re
+import os
 
 import docker
 
@@ -96,6 +97,11 @@ def check_memory_usage(container_name, threshold_value):
         sys.exit(4)
 
 
+def is_service_active(feat):
+    status = os.system('systemctl is-active --quiet {}'.format(feat))
+    return status == 0
+
+
 def get_running_container_names():
     """Retrieves names of running containers by talking to the docker daemon.
 
@@ -105,15 +111,18 @@ def get_running_container_names():
     Returns:
         running_container_names: A list indicates names of running containers.
     """
-    try:
-        docker_client = docker.DockerClient(base_url='unix://var/run/docker.sock')
-        running_container_list = docker_client.containers.list(filters={"status": "running"})
-        running_container_names = [ container.name for container in running_container_list ]
-    except (docker.errors.APIError, docker.errors.DockerException) as err:
-        syslog.syslog(syslog.LOG_ERR,
-                      "Failed to retrieve the running container list from docker daemon! Error message is: '{}'"
-                      .format(err))
-        sys.exit(5)
+    running_container_names = []
+
+    if (is_service_active("docker")):
+        try:
+            docker_client = docker.DockerClient(base_url='unix://var/run/docker.sock')
+            running_container_list = docker_client.containers.list(filters={"status": "running"})
+            running_container_names = [ container.name for container in running_container_list ]
+        except (docker.errors.APIError, docker.errors.DockerException) as err:
+            syslog.syslog(syslog.LOG_ERR,
+                          "Failed to retrieve the running container list from docker daemon! Error message is: '{}'"
+                          .format(err))
+            sys.exit(5)
 
     return running_container_names
 


### PR DESCRIPTION
Fix in Monit memory_checker plugin. Skip fetching running containers if Docker engine is not running (can happen in deinit).
This PR fixes issue https://github.com/Azure/sonic-buildimage/issues/11472.

Signed-off-by: liora <liora@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
In the case where Monit runs during deinit flow, memory_checker plugin is fetching the running containers without checking if Docker service is still running. I added this check.

#### How I did it
Use systemctl is-active to check if Docker engine is still running.

#### How to verify it
Use systemctl to stop docker engine and reload Monit, no errors in log and relevant print appears in log.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->
The fix is required in 202205 and 202012 since the PR that introduced the issue was cherry picked to those branches (https://github.com/Azure/sonic-buildimage/pull/11129).

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

