### PR TITLE
[ZTP]: Add DHCP_L2 and DHCPV6_L2 traps to COPP configuration template

### DIFF
--- a/files/image_config/copp/copp_cfg.j2
+++ b/files/image_config/copp/copp_cfg.j2
@@ -106,6 +106,10 @@
 	    "sflow": {
 		    "trap_group": "queue2_group1",
 		    "trap_ids": "sample_packet"
+	    },
+	    "l2dhcp": {
+	       "trap_ids": "l2dhcp,l2dhcpv6",
+	       "trap_group": "queue4_group2"
 	    }
     }
 }


### PR DESCRIPTION
Signed-off-by: liora <liora@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To enable DHCP packets to CPU on L2 interfaces for getting IP address and DHCP ZTP options.

#### How I did it
Add required traps to COPP configuration template.

#### How to verify it
I have verified both traps are registered when ZTP operation starts and being deleted when ZTP finishes its operation.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

